### PR TITLE
Implement get_element proposal

### DIFF
--- a/libstdc++-v3/include/bits/stl_pair.h
+++ b/libstdc++-v3/include/bits/stl_pair.h
@@ -218,6 +218,38 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 #endif // C++11
 
 #if __glibcxx_tuple_like // >= C++23
+  namespace __detail
+  {
+  template <std::size_t _Ip>
+  struct __get_element_fn
+  {
+      template <typename _TupleLike> requires requires {
+          typename std::tuple_size<std::remove_cvref_t<_TupleLike>>::type;
+      }
+      constexpr auto operator()(_TupleLike&& __tuple_like) const ->
+          decltype(auto)
+      {
+          constexpr bool __get_member_well_formed = requires {
+              std::forward<_TupleLike>(__tuple_like).template get<_Ip>();
+          };
+          if constexpr (__get_member_well_formed)
+          {
+              return std::forward<_TupleLike>(__tuple_like).template get<_Ip>();
+          }
+          return get<_Ip>(std::forward<_TupleLike>(__tuple_like));
+      }
+  };
+  } // namespace __detail
+
+  inline namespace __get_element_namespace
+  {
+  template <std::size_t _Ip>
+  inline constexpr __detail::__get_element_fn<_Ip> get_element;
+  } // inline namespace __get_element_namespace
+
+  inline constexpr auto get_key = get_element<0>;
+  inline constexpr auto get_value = get_element<1>;
+
   template<typename _Tp>
     inline constexpr bool __is_tuple_v = false;
 
@@ -239,8 +271,31 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
   // __is_tuple_like_v<subrange> is defined in <bits/ranges_util.h>.
 
-  template<typename _Tp>
-    concept __tuple_like = __is_tuple_like_v<remove_cvref_t<_Tp>>;
+  // necessary to check if std::tuple_size_v is well-formed before using it
+  template <class _Tp>
+    concept __has_tuple_size = // exposition only
+      requires {
+          typename std::tuple_size<_Tp>::type;
+      };
+
+  template<class _Tp, std::size_t _Ip>
+    concept __can_get_tuple_element = // exposition only
+      __has_tuple_size<std::remove_cvref_t<_Tp>> &&
+      requires(_Tp&& t) {
+          typename std::tuple_element_t<_Ip, std::remove_cvref_t<_Tp>>;
+          { std::get_element<_Ip>(std::forward<_Tp>(t)) } ->
+              std::convertible_to<const std::remove_cvref_t<std::tuple_element_t<_Ip, std::remove_cvref_t<_Tp>>>&>;
+      };
+
+  template <typename _Tp>
+    concept __tuple_like = // exposition only
+      __has_tuple_size<std::remove_cvref_t<_Tp>> &&
+      []<std::size_t... _Ip>(std::index_sequence<_Ip...>) {
+          return (... && __can_get_tuple_element<_Tp, _Ip>);
+      } (std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<_Tp>>>{});
+
+  // template<typename _Tp>
+  //   concept __tuple_like = __is_tuple_like_v<remove_cvref_t<_Tp>>;
 
   template<typename _Tp>
     concept __pair_like = __tuple_like<_Tp> && tuple_size_v<remove_cvref_t<_Tp>> == 2;
@@ -399,24 +454,24 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	static constexpr bool
 	_S_constructible_from_pair_like()
 	{
-	  return _S_constructible<decltype(std::get<0>(std::declval<_UPair>())),
-				  decltype(std::get<1>(std::declval<_UPair>()))>();
+	  return _S_constructible<decltype(std::get_element<0>(std::declval<_UPair>())),
+				  decltype(std::get_element<1>(std::declval<_UPair>()))>();
 	}
 
       template<typename _UPair>
 	static constexpr bool
 	_S_convertible_from_pair_like()
 	{
-	  return _S_convertible<decltype(std::get<0>(std::declval<_UPair>())),
-				decltype(std::get<1>(std::declval<_UPair>()))>();
+	  return _S_convertible<decltype(std::get_element<0>(std::declval<_UPair>())),
+				decltype(std::get_element<1>(std::declval<_UPair>()))>();
 	}
 
       template<typename _UPair>
 	static constexpr bool
 	_S_dangles_from_pair_like()
 	{
-	  return _S_dangles<decltype(std::get<0>(std::declval<_UPair>())),
-			    decltype(std::get<1>(std::declval<_UPair>()))>();
+	  return _S_dangles<decltype(std::get_element<0>(std::declval<_UPair>())),
+			    decltype(std::get_element<1>(std::declval<_UPair>()))>();
 	}
 #endif // C++23
       /// @endcond
@@ -523,8 +578,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  && (!_S_dangles_from_pair_like<_UPair>())
 	constexpr explicit(!_S_convertible_from_pair_like<_UPair>())
 	pair(_UPair&& __p)
-	: first(std::get<0>(std::forward<_UPair>(__p))),
-	  second(std::get<1>(std::forward<_UPair>(__p)))
+	: first(std::get_element<0>(std::forward<_UPair>(__p))),
+	  second(std::get_element<1>(std::forward<_UPair>(__p)))
 	{ }
 
       template<__eligible_pair_like<pair> _UPair>
@@ -568,16 +623,16 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	static constexpr bool
 	_S_assignable_from_tuple_like()
 	{
-	  return _S_assignable<decltype(std::get<0>(std::declval<_UPair>())),
-			       decltype(std::get<1>(std::declval<_UPair>()))>();
+	  return _S_assignable<decltype(std::get_element<0>(std::declval<_UPair>())),
+			       decltype(std::get_element<1>(std::declval<_UPair>()))>();
 	}
 
       template<typename _UPair>
 	static constexpr bool
 	_S_const_assignable_from_tuple_like()
 	{
-	  return _S_const_assignable<decltype(std::get<0>(std::declval<_UPair>())),
-				     decltype(std::get<1>(std::declval<_UPair>()))>();
+	  return _S_const_assignable<decltype(std::get_element<0>(std::declval<_UPair>())),
+				     decltype(std::get_element<1>(std::declval<_UPair>()))>();
 	}
 #endif // C++23
       /// @endcond
@@ -682,8 +737,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr pair&
 	operator=(_UPair&& __p)
 	{
-	  first = std::get<0>(std::forward<_UPair>(__p));
-	  second = std::get<1>(std::forward<_UPair>(__p));
+	  first = std::get_element<0>(std::forward<_UPair>(__p));
+	  second = std::get_element<1>(std::forward<_UPair>(__p));
 	  return *this;
 	}
 
@@ -692,8 +747,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr const pair&
 	operator=(_UPair&& __p) const
 	{
-	  first = std::get<0>(std::forward<_UPair>(__p));
-	  second = std::get<1>(std::forward<_UPair>(__p));
+	  first = std::get_element<0>(std::forward<_UPair>(__p));
+	  second = std::get_element<1>(std::forward<_UPair>(__p));
 	  return *this;
 	}
 #endif // C++23

--- a/libstdc++-v3/include/std/ranges
+++ b/libstdc++-v3/include/std/ranges
@@ -5399,7 +5399,7 @@ namespace views::__adaptor
   {
     // Yields tuple<_Tp, ..., _Tp> with _Nm elements.
     template<typename _Tp, size_t _Nm>
-      using __repeated_tuple = decltype(std::tuple_cat(std::declval<array<_Tp, _Nm>>()));
+      using __repeated_tuple = decltype(std::tuple_cat(std::declval<array<std::decay_t<_Tp>, _Nm>>()));
 
     // For a functor F that is callable with N arguments, the expression
     // declval<__unarize<F, N>>(x) is equivalent to declval<F>(x, ..., x).

--- a/libstdc++-v3/include/std/ranges
+++ b/libstdc++-v3/include/std/ranges
@@ -4283,7 +4283,11 @@ namespace views::__adaptor
 	  {
 	    using _Base = elements_view::_Base<_Const>;
 	    using _Cat = typename iterator_traits<iterator_t<_Base>>::iterator_category;
+#if __cpp_lib_tuple_like // >= C++23
+	    using _Res = decltype((std::get_element<_Nm>(*std::declval<iterator_t<_Base>>())));
+#else
 	    using _Res = decltype((std::get<_Nm>(*std::declval<iterator_t<_Base>>())));
+#endif
 	    if constexpr (!is_lvalue_reference_v<_Res>)
 	      return input_iterator_tag{};
 	    else if constexpr (derived_from<_Cat, random_access_iterator_tag>)
@@ -4310,11 +4314,19 @@ namespace views::__adaptor
 	  _S_get_element(const iterator_t<_Base>& __i)
 	  {
 	    if constexpr (is_reference_v<range_reference_t<_Base>>)
-	      return std::get<_Nm>(*__i);
+#if __cpp_lib_tuple_like // >= C++23
+	      return std::get_element<_Nm>(*__i);
+#else
+        return std::get<_Nm>(*__i);
+#endif
 	    else
 	      {
 		using _Et = remove_cv_t<tuple_element_t<_Nm, range_reference_t<_Base>>>;
+#if __cpp_lib_tuple_like // >= C++23
+		return static_cast<_Et>(std::get_element<_Nm>(*__i));
+#else
 		return static_cast<_Et>(std::get<_Nm>(*__i));
+#endif
 	      }
 	  }
 

--- a/libstdc++-v3/include/std/tuple
+++ b/libstdc++-v3/include/std/tuple
@@ -363,7 +363,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       template<typename _UTuple, size_t... _Is>
 	constexpr
 	_Tuple_impl(__tuple_like_tag_t, _UTuple&& __u, index_sequence<_Is...>)
-	: _Tuple_impl(std::get<_Is>(std::forward<_UTuple>(__u))...)
+	: _Tuple_impl(std::get_element<_Is>(std::forward<_UTuple>(__u))...)
 	{ }
 #endif // C++23
 
@@ -458,7 +458,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr
 	_Tuple_impl(__tuple_like_tag_t, allocator_arg_t __tag, const _Alloc& __a,
 		    _UTuple&& __u, index_sequence<_Is...>)
-	: _Tuple_impl(__tag, __a, std::get<_Is>(std::forward<_UTuple>(__u))...)
+	: _Tuple_impl(__tag, __a, std::get_element<_Is>(std::forward<_UTuple>(__u))...)
 	{ }
 #endif // C++23
 
@@ -509,7 +509,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr void
 	_M_assign(__tuple_like_tag_t __tag, _UTuple&& __u)
 	{
-	  _M_head(*this) = std::get<_Idx>(std::forward<_UTuple>(__u));
+	  _M_head(*this) = std::get_element<_Idx>(std::forward<_UTuple>(__u));
 	  _M_tail(*this)._M_assign(__tag, std::forward<_UTuple>(__u));
 	}
 
@@ -517,7 +517,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr void
 	_M_assign(__tuple_like_tag_t __tag, _UTuple&& __u) const
 	{
-	  _M_head(*this) = std::get<_Idx>(std::forward<_UTuple>(__u));
+	  _M_head(*this) = std::get_element<_Idx>(std::forward<_UTuple>(__u));
 	  _M_tail(*this)._M_assign(__tag, std::forward<_UTuple>(__u));
 	}
 #endif // C++23
@@ -619,7 +619,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       template<typename _UTuple>
 	constexpr
 	_Tuple_impl(__tuple_like_tag_t, _UTuple&& __u, index_sequence<0>)
-	: _Tuple_impl(std::get<0>(std::forward<_UTuple>(__u)))
+	: _Tuple_impl(std::get_element<0>(std::forward<_UTuple>(__u)))
 	{ }
 #endif // C++23
 
@@ -698,7 +698,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	constexpr
 	_Tuple_impl(__tuple_like_tag_t, allocator_arg_t __tag, const _Alloc& __a,
 		    _UTuple&& __u, index_sequence<0>)
-	: _Tuple_impl(__tag, __a, std::get<0>(std::forward<_UTuple>(__u)))
+	: _Tuple_impl(__tag, __a, std::get_element<0>(std::forward<_UTuple>(__u)))
 	{ }
 #endif // C++23
 
@@ -740,12 +740,12 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     template<typename _UTuple>
       constexpr void
       _M_assign(__tuple_like_tag_t, _UTuple&& __u)
-      { _M_head(*this) = std::get<_Idx>(std::forward<_UTuple>(__u)); }
+      { _M_head(*this) = std::get_element<_Idx>(std::forward<_UTuple>(__u)); }
 
     template<typename _UTuple>
       constexpr void
       _M_assign(__tuple_like_tag_t, _UTuple&& __u) const
-      { _M_head(*this) = std::get<_Idx>(std::forward<_UTuple>(__u)); }
+      { _M_head(*this) = std::get_element<_Idx>(std::forward<_UTuple>(__u)); }
 #endif // C++23
 
     protected:
@@ -935,7 +935,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__dangles_from_tuple_like()
 	{
 	  return []<size_t... _Is>(index_sequence<_Is...>) {
-	    return __dangles<decltype(std::get<_Is>(std::declval<_UTuple>()))...>();
+	    return __dangles<decltype(std::get_element<_Is>(std::declval<_UTuple>()))...>();
 	  }(index_sequence_for<_Elements...>{});
 	}
 
@@ -944,7 +944,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__constructible_from_tuple_like()
 	{
 	  return []<size_t... _Is>(index_sequence<_Is...>) {
-	    return __constructible<decltype(std::get<_Is>(std::declval<_UTuple>()))...>();
+	    return __constructible<decltype(std::get_element<_Is>(std::declval<_UTuple>()))...>();
 	  }(index_sequence_for<_Elements...>{});
 	}
 
@@ -953,7 +953,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__convertible_from_tuple_like()
 	{
 	  return []<size_t... _Is>(index_sequence<_Is...>) {
-	    return __convertible<decltype(std::get<_Is>(std::declval<_UTuple>()))...>();
+	    return __convertible<decltype(std::get_element<_Is>(std::declval<_UTuple>()))...>();
 	  }(index_sequence_for<_Elements...>{});
 	}
 #endif // C++23
@@ -1690,7 +1690,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__assignable_from_tuple_like()
 	{
 	  return []<size_t... _Is>(index_sequence<_Is...>) {
-	    return __assignable<decltype(std::get<_Is>(std::declval<_UTuple>()))...>();
+	    return __assignable<decltype(std::get_element<_Is>(std::declval<_UTuple>()))...>();
 	  }(index_sequence_for<_Elements...>{});
 	}
 
@@ -1699,7 +1699,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	__const_assignable_from_tuple_like()
 	{
 	  return []<size_t... _Is>(index_sequence<_Is...>) {
-	    return __const_assignable<decltype(std::get<_Is>(std::declval<_UTuple>()))...>();
+	    return __const_assignable<decltype(std::get_element<_Is>(std::declval<_UTuple>()))...>();
 	  }(index_sequence_for<_Elements...>{});
 	}
 #endif // C++23
@@ -1853,7 +1853,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  static_assert(sizeof...(_Elements) == tuple_size_v<_UTuple>,
 	      "tuple objects can only be compared if they have equal sizes.");
 	  return [&]<size_t... _Is>(index_sequence<_Is...>) {
-	    return (bool(std::get<_Is>(__t) == std::get<_Is>(__u))
+	    return (bool(std::get_element<_Is>(__t) == std::get_element<_Is>(__u))
 		    && ...);
 	  }(index_sequence_for<_Elements...>{});
 	}
@@ -2577,7 +2577,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 		index_sequence<_Idx0, _Idxs...>)
     {
       auto __c
+#if __cpp_lib_tuple_like // >= C++23
+	= __detail::__synth3way(std::get_element<_Idx0>(__t), std::get_element<_Idx0>(__u));
+#else
 	= __detail::__synth3way(std::get<_Idx0>(__t), std::get<_Idx0>(__u));
+#endif
       if (__c != 0)
 	return __c;
       return std::__tuple_cmp<_Cat>(__t, __u, index_sequence<_Idxs...>());
@@ -2744,7 +2748,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  typedef __tuple_concater<_Ret, __idx, _Tpls...>      __next;
 	  return __next::_S_do(std::forward<_Tpls>(__tps)...,
 			       std::forward<_Us>(__us)...,
+#if __cpp_lib_tuple_like // >= C++23	  
+			       std::get_element<_Is>(std::forward<_Tp>(__tp))...);
+#else
 			       std::get<_Is>(std::forward<_Tp>(__tp))...);
+#endif
 	}
     };
 
@@ -2919,7 +2927,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     __apply_impl(_Fn&& __f, _Tuple&& __t, index_sequence<_Idx...>)
     {
       return std::__invoke(std::forward<_Fn>(__f),
-			   std::get<_Idx>(std::forward<_Tuple>(__t))...);
+#if __cpp_lib_tuple_like // >= C++23
+			   std::get_element<_Idx>(std::forward<_Tuple>(__t))...);
+#else
+               std::get<_Idx>(std::forward<_Tuple>(__t))...);
+#endif
     }
 
 #if __cpp_lib_tuple_like // >= C++23
@@ -2943,7 +2955,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   template <typename _Tp, typename _Tuple, size_t... _Idx>
     constexpr _Tp
     __make_from_tuple_impl(_Tuple&& __t, index_sequence<_Idx...>)
-    { return _Tp(std::get<_Idx>(std::forward<_Tuple>(__t))...); }
+#if __cpp_lib_tuple_like // >= C++23
+    { return _Tp(std::get_element<_Idx>(std::forward<_Tuple>(__t))...); }
+#else
+	{ return _Tp(std::get<_Idx>(std::forward<_Tuple>(__t))...); }
+#endif
 
 #if __cpp_lib_tuple_like // >= C++23
   template <typename _Tp, __tuple_like _Tuple>
@@ -2958,7 +2974,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 #if __has_builtin(__reference_constructs_from_temporary)
       if constexpr (__n == 1)
 	{
+#if __cpp_lib_tuple_like // >= C++23
+	  using _Elt = decltype(std::get_element<0>(std::declval<_Tuple>()));
+#else
 	  using _Elt = decltype(std::get<0>(std::declval<_Tuple>()));
+#endif
 	  static_assert(!__reference_constructs_from_temporary(_Tp, _Elt));
 	}
 #endif

--- a/libstdc++-v3/testsuite/20_util/tuple/p2165r4.cc
+++ b/libstdc++-v3/testsuite/20_util/tuple/p2165r4.cc
@@ -308,12 +308,12 @@ test05()
   // template<tuple-like TTuple, tuple-like UTuple>
   //   struct common_type<TTuple, UTuple>;
 
-  static_assert( std::same_as<std::common_type_t<tuple_like_t<const int&>,
+  static_assert( std::same_as<std::common_type_t<tuple_like_t<const int>,
 						 tuple<int, long, int>>,
 			      tuple<int, long, int>> );
 
   static_assert( std::same_as<std::common_type_t<tuple<int, long, int>,
-						 tuple_like_t<const int&>>,
+						 tuple_like_t<const int>>,
 			      tuple<int, long, int>> );
 
   return true;


### PR DESCRIPTION
This PR is an implementation experience for [get_element](https://wg21.link/P2769) proposal.

- The diff is made against gcc-14 release
- All tests passed. That mean that there are 32 failed tests with and without code modifications. Nothing new appeared due to the code modification
- `std::decay_t` is a stub in `<ranges>` header, line: 5414. It can be fixed using different techniques, without ёstd::arrayё. The line with new definition of `tuple-like` concept can be fixed silently for the users and doesn't break their code. However, that leads to the following conclusion: whatever code uses the API with `tuple-like` parameters for metaprogramming and relies on the fact, that this very `tuple-like` can be ill-formed, stops working with a new `tuple-like` definition.
- The only broken test is `std::common_type`. In the current standard `std::common_type_t<std::tuple<int> std::array<int&, 1>>`  works; with modified `tuple-like` concept (using `get_element`) it stops working. The key difference is that the C++23 definition of `tuple-like` doesn't require it to instantiate class templates, only check for specialization. Whether it's intentional or not, I don't know. The new one does requires class template instantiation. thus `std::array` from `int&` is ill-formed.